### PR TITLE
fix: parameters starting with "/" have invalid IAM policy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ class SecureParameterProvider extends Construct {
     const lambdaName = nameGenerator.getPrefixedName('handler');
     const customResourceProviderName = nameGenerator.getPrefixedName('customResourceProvider');
     const handlerPath = path.join(path.dirname(__dirname), 'functions');
+    const iamResourceName = name.startsWith("/") ? name.substring(1) : name;
 
     const onEvent = new Function(scope, lambdaName, {
       handler: 'index.handler',
@@ -65,7 +66,7 @@ class SecureParameterProvider extends Construct {
         new PolicyStatement({
           actions: ['ssm:*'],
           resources: [
-            `arn:aws:ssm:${Stack.of(scope).region}:${Stack.of(scope).account}:parameter/${name}`,
+            `arn:aws:ssm:${Stack.of(scope).region}:${Stack.of(scope).account}:parameter/${iamResourceName}`,
           ],
         }),
       ],


### PR DESCRIPTION
If you try to create an SSM parameter currently that uses a path or prefix like `/some/parameter/here` - the resource ARN is constructed incorrectly.